### PR TITLE
Branch small bug fixes

### DIFF
--- a/src/main/java/gui/GameOverState.java
+++ b/src/main/java/gui/GameOverState.java
@@ -162,7 +162,11 @@ public class GameOverState extends BasicGameState {
 	public void exit(GameContainer container, StateBasedGame sbg, int delta) {
 		if (mg.getShouldSwitchState()) {
 			if (RND.getOpacity() > 0.0f) {
-				RND.setOpacity(RND.getOpacity() - ((float) delta) / mg.getOpacityFadeTimer());
+				int fadeTimer = mg.getOpacityFadeTimer();
+				if (mg.getSwitchState() == -1) {
+					fadeTimer = 2 * 2 * 2 * fadeTimer;
+				}
+				RND.setOpacity(RND.getOpacity() - ((float) delta) / fadeTimer);
 			} else {
 				if (mg.getSwitchState() == -1) {
 					container.exit();

--- a/src/main/java/gui/GameState.java
+++ b/src/main/java/gui/GameState.java
@@ -179,7 +179,7 @@ public class GameState extends BasicGameState {
 	private static final int COUNTER_BAR_DRAW_Y_DEVIATION = 91;
 	private static final int AMOUNT_OF_BALLS = 6;
 	private static final int POWERUP_CHANCE = 20;
-	private static final int COIN_CHANCE = 100;
+	private static final int COIN_CHANCE = 30;
 	private static final int POWERUP_IMAGE_OFFSET = 12;
 	private static final int COIN_IMAGE_OFFSET = 3;
 	// Level ending, empty bar
@@ -296,7 +296,7 @@ public class GameState extends BasicGameState {
 			RND.setOpacity(RND.getOpacity() + ((float) delta) / mg.getOpacityFadeTimer());
 		}
 		setSavedInput(container.getInput());
-		if (playingState) {
+		if (playingState && !mg.getShouldSwitchState()) {
 			// Timer logic
 			long curTime = System.currentTimeMillis();
 			timeDelta = curTime - prevTime;
@@ -334,7 +334,7 @@ public class GameState extends BasicGameState {
 		// if there are no circles required to be shot by a gate, remove said gate
 		updateGateExistence(deltaFloat);
 		// if there are no active circles, process to gameover screen
-
+		processCoins(container, deltaFloat);
 		if (circleList.isEmpty()) {
 			endLevel(sbg);
 		}
@@ -369,12 +369,17 @@ public class GameState extends BasicGameState {
 			} else if (menuButton.getRectangle().contains(MOUSE_OVER_RECT_X, input.getMouseY())) {
 				mg.setScore(0);
 				mg.setLevelCounter(0);
-				//sbg.enterState(0);
 				mg.setSwitchState(mg.getStartState());
 			} else if (exitButton.getRectangle().contains(MOUSE_OVER_RECT_X, input.getMouseY())) {
 				mg.setSwitchState(-1);
 				container.exit();
 			}
+		}
+	}
+	
+	private void processCoins(GameContainer container, float deltafloat) {
+		for (Coin coin : droppedCoins) {
+			coin.update(getFloor(), deltafloat, container.getHeight() );
 		}
 	}
 	
@@ -479,10 +484,12 @@ public class GameState extends BasicGameState {
 			if (levelCounter < levels.size() - 1) {
                 waitForLevelEnd = false;
                 mg.setLevelCounter(mg.getLevelCounter() + 1);
-                sbg.enterState(mg.getGameState()); // next level
+                //sbg.enterState(mg.getGameState()); // next level
+                mg.setSwitchState(mg.getGameState());
             } else {
                 waitForLevelEnd = false;
-                sbg.enterState(mg.getGameOverState()); // game completed
+               // sbg.enterState(mg.getGameOverState()); // game completed
+                mg.setSwitchState(mg.getGameOverState());
             }
         }
 	}
@@ -630,6 +637,7 @@ public class GameState extends BasicGameState {
 	private void drawCoins(Graphics graphics) {
 		graphics.setColor(Color.blue);
 		for (Coin coin : droppedCoins) {
+			System.out.println(coin.getX() + " " + coin.getY());
 			RND.drawColor(graphics, coinImageN, coinImageA, 
 					coin.getX() - COIN_IMAGE_OFFSET, coin.getY() - COIN_IMAGE_OFFSET,
 					mg.getColor());

--- a/src/main/java/gui/GameState.java
+++ b/src/main/java/gui/GameState.java
@@ -242,7 +242,11 @@ public class GameState extends BasicGameState {
 	public void exit(GameContainer container, StateBasedGame sbg, int delta) {
 		if (mg.getShouldSwitchState()) {
 			if (RND.getOpacity() > 0.0f) {
-				RND.setOpacity(RND.getOpacity() - ((float) delta) / mg.getOpacityFadeTimer());
+				int fadeTimer = mg.getOpacityFadeTimer();
+				if (mg.getSwitchState() == -1) {
+					fadeTimer = 2 * 2 * 2 * fadeTimer;
+				}
+				RND.setOpacity(RND.getOpacity() - ((float) delta) / fadeTimer);
 			} else {
 				if (mg.getSwitchState() == -1) {
 					container.exit();
@@ -372,7 +376,6 @@ public class GameState extends BasicGameState {
 				mg.setSwitchState(mg.getStartState());
 			} else if (exitButton.getRectangle().contains(MOUSE_OVER_RECT_X, input.getMouseY())) {
 				mg.setSwitchState(-1);
-				container.exit();
 			}
 		}
 	}

--- a/src/main/java/gui/GameState.java
+++ b/src/main/java/gui/GameState.java
@@ -543,8 +543,14 @@ public class GameState extends BasicGameState {
 		RND.text(graphics, container.getWidth() / 2 - LEVEL_STRING_X_DEVIATION, 
 				container.getHeight() - LEVEL_STRING_Y_DEVIATION, "Level: "
 						+ Integer.toString(mg.getLevelCounter() + 1));
+		String renderedScore;
+		if (mg.getShouldSwitchState()) {
+			renderedScore = Integer.toString(mg.getScore());
+		} else {
+			renderedScore = Integer.toString(mg.getScore() + score);
+		}
 		RND.text(graphics, (float) container.getWidth() / 2.0f, container.getHeight()
-				- SCORE_STRING_Y_DEVIATION, "Score: " + Integer.toString(mg.getScore() + score));
+				- SCORE_STRING_Y_DEVIATION, "Score: " + renderedScore);
 		// Pause overlay and counter
 		if (playingState && countIn) {
 			drawCountIn(container, graphics);

--- a/src/main/java/gui/MainGame.java
+++ b/src/main/java/gui/MainGame.java
@@ -83,7 +83,7 @@ public class MainGame extends StateBasedGame {
 	private static AppGameContainer app;
 	private GameContainer container;
 	
-	private static final int OPACITY_FADE_TIMER = 150;
+	private static final int OPACITY_FADE_TIMER = 200;
 	private static final int TARGET_FRAMERATE = 60;
 	private static final float DEFAULT_GRAVITY = 500f;
 	private static final float DEFAULT_STARTING_SPEED = 200f;

--- a/src/main/java/gui/RND.java
+++ b/src/main/java/gui/RND.java
@@ -163,13 +163,20 @@ public final class RND {
 	 * @param newColor color to set
 	 */
 	public static void text(Graphics g, 
-			float x, float y, String text, Color newColor) {
+			float x, float y, String text, Color color) {
+		Color newColor;
 		
-		dosFontN.drawString(x, y, text, new Color(newColor.r, newColor.g, newColor.b, opacity));
-		if (newColor.a == 1.0f) {
+		if(color.a < 1.0f) {
+			newColor = new Color(color.r, color.g, color.b, color.a);
+		} else {
+			newColor = new Color(color.r, color.g, color.b, opacity);
+		}
+		
+		dosFontN.drawString(x, y, text, newColor);
+		if (color.a == 1.0f) {
 			g.setDrawMode(Graphics.MODE_ADD);
 			dosFontA.drawString(x, y, text, 
-					new Color(newColor.r * opacity, newColor.g * opacity, newColor.b * opacity));
+					new Color(color.r * opacity, color.g * opacity, color.b * opacity));
 			g.setDrawMode(Graphics.MODE_NORMAL);
 		}
 		

--- a/src/main/java/gui/StartState.java
+++ b/src/main/java/gui/StartState.java
@@ -103,7 +103,11 @@ public class StartState extends BasicGameState {
 	public void exit(GameContainer container, StateBasedGame sbg, int delta) {
 		if (mg.getShouldSwitchState()) {
 			if (RND.getOpacity() > 0.0f) {
-				RND.setOpacity(RND.getOpacity() - ((float) delta) / mg.getOpacityFadeTimer());
+				int fadeTimer = mg.getOpacityFadeTimer();
+				if (mg.getSwitchState() == -1) {
+					fadeTimer = 2 * 2 * 2 * fadeTimer;
+				}
+				RND.setOpacity(RND.getOpacity() - ((float) delta) / fadeTimer);
 			} else {
 				if (mg.getSwitchState() == -1) {
 					container.exit();

--- a/src/main/java/logic/Player.java
+++ b/src/main/java/logic/Player.java
@@ -155,7 +155,6 @@ public class Player {
 	private void processCoins(float deltaFloat, float containerHeight) {
 		ArrayList<Coin> usedCoins = new ArrayList<>();
 		for (Coin coin : gs.getDroppedCoins()) {
-			coin.update(gs.getFloor(), containerHeight, deltaFloat);
 
 			if (coin.getRectangle().intersects(this.getRectangle())) {
 				gs.addToScore(coin.getPoints());

--- a/src/main/java/logic/PlayerList.java
+++ b/src/main/java/logic/PlayerList.java
@@ -57,6 +57,7 @@ public class PlayerList {
 		if (mg.isMultiplayer()) {
 			playerList.get(1).update(deltaFloat, containerHeight, containerWidth, false);	
 		}
+		
 	}
 	
 	/**


### PR DESCRIPTION
Fixed bugs with the state transitions. This includes
- A bug where the transition did not happen, or happened too quickly, on death
- A bug where your score was displayed incorrectly on a levelswitch
- A bug where you could somehow end up losing 5 lives because the scene was still going

Fixed bugs with the coins. This includes
- Coins not dropping at all, because some variables were switched.
- Coins updating twice in multiplayer. They were never adapted for it.

Miscellaneous fixes/tweaks
- Floating scores now properly fade out again
- Exiting the game now also has a state transition, which is slightly slower.

If, in the coming days, you notice any bugs at all with state-switches, be it level, score, lives or the player dying a lot, tell me.

> bug 
> logic
> feature
